### PR TITLE
Changed output form pdf to png

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-# Main Makefile — Full Pipeline
+# Main Makefile — Full Pipeline (PNG output)
 
 MAKE := "$(MAKE)"
 
@@ -13,18 +13,13 @@ OUT  := gen/output
 .DEFAULT_GOAL := all
 
 # Main build rule
-all: $(OUT)/report.pdf
+all: $(OUT)/report.png
 
-# Generate the final report
-$(OUT)/report.pdf: $(TEMP)/final_dataset.csv
+# Generate the final report (built by Stage 3 and copied as report.png)
+$(OUT)/report.png: $(TEMP)/final_dataset.csv
 	$(MAKE) -C src/3-analysis all
-	Rscript -e "file.copy('$(OUT)/analysis_output.pdf', '$(OUT)/report.pdf', overwrite=TRUE)"
+	Rscript -e "file.copy('$(OUT)/analysis_output.png', '$(OUT)/report.png', overwrite=TRUE)"
 	@echo "All analysis and plots saved in $(OUT)"
-
-# Stage 3 — Analysis and Visualization
-$(OUT)/report.pdf: $(TEMP)/final_dataset.csv
-	$(MAKE) -C src/3-analysis all
-	Rscript -e "file.copy('$(OUT)/analysis_output.pdf', '$(OUT)/report.pdf', overwrite=TRUE)"
 
 # Stage 2 — Data Preparation
 $(TEMP)/final_dataset.csv: $(DATA)/photos.csv $(DATA)/business.csv src/2-data-preparation/clean.R

--- a/src/3-analysis/analysis.R
+++ b/src/3-analysis/analysis.R
@@ -1,53 +1,74 @@
-## Upload all necessary packages to library
-library(dplyr)
-library(tidyr)
-library(ggplot2)
-library(rmarkdown)
+# ===========================
+# Analysis Script -> PNG
+# ===========================
 
-# Load the final dataset (path relative to src/3-analysis)
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(tidyr)
+  library(ggplot2)
+  library(rmarkdown)
+})
+
+# ---- Load dataset ----
 final_dataset <- read.csv("../../gen/temp/final_dataset.csv")
 
-# BASELINE ANALYSIS
+# ---- Run models ----
 main_effect <- lm(stars ~ total_photos, data = final_dataset)
-summary(main_effect)
-
 model_categories <- lm(stars ~ food_and_drink + menu + environment, data = final_dataset)
-summary(model_categories)
 
-# MAIN MODEL: Linear regression with moderators
 mean_photos <- mean(final_dataset$total_photos)
 final_dataset <- final_dataset %>%
   mutate(photos_centered = total_photos - mean_photos)
-
 model_central_moderation <- lm(stars ~ photos_centered * photo_category_dominant, data = final_dataset)
-summary(model_central_moderation)
 
-# Prepare R Markdown file and output locations
+# ---- Output paths ----
 output_dir <- "../../gen/output"
 dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
 
-rmd_file <- file.path(output_dir, "analysis_report.Rmd")
-output_pdf <- file.path(output_dir, "analysis_output.pdf")
+rmd_file   <- file.path(output_dir, "analysis_report.Rmd")
+output_png <- file.path(output_dir, "analysis_output.png")
 
-# Write R Markdown content
+# ---- Write R Markdown file ----
 rmd_content <- '
 ---
 title: "Analysis Report"
-output: pdf_document
+output: html_document
 ---
 
 ```{r}
 summary(main_effect)
 summary(model_categories)
 summary(model_central_moderation)
-```'
+
+'
 
 writeLines(rmd_content, con = rmd_file)
 
-# Render directly to PDF in gen/output
-rmarkdown::render(
-  input = rmd_file,
-  output_file = output_pdf
-)
+#---- Render the HTML report ----
+  
+  html_file <- rmarkdown::render(
+    input = rmd_file,
+    output_format = "html_document",
+    envir = globalenv(),
+    quiet = TRUE
+  )
 
-cat("Analysis report successfully created in", output_pdf, "\n")
+#---- Ensure webshot2 is available, then convert HTML -> PNG ----
+  
+  if (!requireNamespace("webshot2", quietly = TRUE)) {
+    install.packages("webshot2")
+  }
+if (requireNamespace("webshot", quietly = TRUE)) {
+  try(webshot::install_phantomjs(), silent = TRUE)
+}
+
+library(webshot2)
+webshot(html_file, file = output_png, vwidth = 1200, vheight = 1600)
+
+cat("Analysis report successfully created as PNG at", output_png, "\n")
+
+
+
+  
+  
+

--- a/src/3-analysis/makefile
+++ b/src/3-analysis/makefile
@@ -1,4 +1,4 @@
-# Stage 3 — Analysis and Visualization
+# Stage 3 — Analysis and Visualization (PNG)
 
 # Paths
 DATA_DIR    = ../../gen/temp
@@ -9,9 +9,9 @@ ROOT        = $(abspath ../..)
 VISUALIZE_SCRIPT = $(SCRIPT_DIR)/visualize.R
 ANALYSIS_SCRIPT  = $(SCRIPT_DIR)/analysis.R
 INPUT_DATA       = $(DATA_DIR)/final_dataset.csv
-OUTPUT_PDF       = $(OUTPUT_DIR)/analysis_output.pdf
+OUTPUT_PNG       = $(OUTPUT_DIR)/analysis_output.png
 RMD_FILE         = $(OUTPUT_DIR)/analysis_report.Rmd
-REPORT_PDF       = $(OUTPUT_DIR)/analysis_output.pdf
+REPORT_PNG       = $(OUTPUT_DIR)/analysis_output.png
 
 .PHONY: all clean visualize analysis
 
@@ -19,17 +19,20 @@ REPORT_PDF       = $(OUTPUT_DIR)/analysis_output.pdf
 all: visualize analysis
 
 # Visualization step
-visualize: $(VISUALIZE_SCRIPT)
+visualize: $(VISUALIZE_SCRIPT) $(INPUT_DATA)
 	R -e "dir.create('$(OUTPUT_DIR)', recursive = TRUE)"
-	Rscript visualize.R
+	Rscript $(VISUALIZE_SCRIPT)
 
 # Analysis step
-analysis: $(ANALYSIS_SCRIPT)
+analysis: $(ANALYSIS_SCRIPT) $(INPUT_DATA)
 	R -e "dir.create('$(OUTPUT_DIR)', recursive = TRUE)"
-	Rscript analysis.R
+	Rscript $(ANALYSIS_SCRIPT)
 
 # Clean outputs
 clean:
-	rm -f $(OUTPUT_DIR)/analysis_output.pdf
+	rm -f $(OUTPUT_DIR)/analysis_output.png
 	rm -f $(OUTPUT_DIR)/analysis_report.Rmd
+	rm -f $(OUTPUT_DIR)/stars_vs_photos.png
+	rm -f $(OUTPUT_DIR)/photos_per_category.png
 	@echo "Cleaned analysis output files."
+

--- a/src/3-analysis/visualize.R
+++ b/src/3-analysis/visualize.R
@@ -1,18 +1,22 @@
-# LOAD PACKAGES
-library(dplyr)
-library(tidyr)
-library(ggplot2)
+# ===========================
+# Visualization -> PNG files
+# ===========================
 
-# LOAD DATA
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(tidyr)
+  library(ggplot2)
+})
+
+# ---- Load data ----
 final_dataset <- read.csv("../../gen/temp/final_dataset.csv")
 
-# ENSURE OUTPUT DIRECTORY EXISTS
-dir.create("../../gen/output", recursive = TRUE, showWarnings = FALSE)
+# ---- Ensure output directory exists ----
+out_dir <- "../../gen/output"
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
-# OPEN PDF DEVICE
-pdf("../../gen/output/visualizations.pdf")
-
-# PLOT A — Stars vs Total Photos
+# ---- Plot A — Stars vs Total Photos ----
+png(file.path(out_dir, "stars_vs_photos.png"), width = 1200, height = 900, res = 144)
 print(
   ggplot(final_dataset, aes(x = total_photos, y = stars)) +
     geom_point(alpha = 0.4, color = "blue") +
@@ -23,17 +27,19 @@ print(
     ) +
     theme_minimal(base_size = 14)
 )
+dev.off()
 
-# PLOT B — Total Photos per Category
-plot_data <- data.frame(
+# ---- Plot B — Total Photos per Category ----
+plot_data <- tibble::tibble(
   photo_type = c("Environment", "Food_and_Drink", "Menu"),
   total = c(
-    sum(final_dataset$environment, na.rm = TRUE),
-    sum(final_dataset$food_and_drink, na.rm = TRUE),
-    sum(final_dataset$menu, na.rm = TRUE)
+    sum(final_dataset$environment,     na.rm = TRUE),
+    sum(final_dataset$food_and_drink,  na.rm = TRUE),
+    sum(final_dataset$menu,            na.rm = TRUE)
   )
 )
 
+png(file.path(out_dir, "photos_per_category.png"), width = 1200, height = 900, res = 144)
 print(
   ggplot(plot_data, aes(x = photo_type, y = total, fill = photo_type)) +
     geom_col() +
@@ -42,11 +48,9 @@ print(
       x = "Photo Type",
       y = "Total Photos"
     ) +
-    theme_minimal(base_size = 14)
+    theme_minimal(base_size = 14) +
+    theme(legend.position = "none")
 )
-
-# FORCE FLUSH + CLOSE DEVICE
-dev.flush()
 dev.off()
 
-cat("PDF with plots successfully saved to ../../gen/output/report.pdf\n")
+cat("PNG plots saved to", out_dir, "\n")


### PR DESCRIPTION
- Updated the main Makefile to target report.png instead of report.pdf.
- Modified src/3-analysis/Makefile to produce .png outputs.
- Updated analysis.R to:
1. Render R Markdown to HTML.
2. Convert the HTML report to PNG using webshot2.
- Updated visualize.R to export individual plots as PNGs.
- Cleaned old PDF references and output paths.